### PR TITLE
remove hardcoding of ble_timeout

### DIFF
--- a/mitemp_bt/mitemp_bt_poller.py
+++ b/mitemp_bt/mitemp_bt_poller.py
@@ -65,7 +65,8 @@ class MiTempBtPoller(object):
 
         with self._bt_interface.connect(self._mac) as connection:
             try:
-                connection.wait_for_notification(_HANDLE_READ_WRITE_SENSOR_DATA, self, 10)  # pylint: disable=no-member
+                connection.wait_for_notification(_HANDLE_READ_WRITE_SENSOR_DATA, self,
+                                                 self.ble_timeout)  # pylint: disable=no-member
                 # If a sensor doesn't work, wait 5 minutes before retrying
             except BluetoothBackendException:
                 self._last_read = datetime.now() - self._cache_timeout + \


### PR DESCRIPTION
the ble_timeout is an attribute, but it was passed hardcoded as `10`.

This fixes a problem in Home Assistant, which actually uses the attribute to update the number: https://github.com/home-assistant/home-assistant/blob/1be440a72b79c96d633ed796b16f802e6aa0a1f2/homeassistant/components/sensor/mitemp_bt.py#L77

Does not change anything by default as `self.ble_timeout` is set to 10.