### PR TITLE
Fix Issue #15 float conversion exception

### DIFF
--- a/mitemp_bt/mitemp_bt_poller.py
+++ b/mitemp_bt/mitemp_bt_poller.py
@@ -171,9 +171,12 @@ class MiTempBtPoller(object):
         https://github.com/ratcashdev/mitemp/issues/2#issuecomment-406263635
         """
         data = self._cache
+        # Sanitizing the input sometimes has spurious binary data
+        data = data.strip('\0')
+        data = ''.join(filter(lambda i: i.isprintable(), data))
 
         res = dict()
-        for dataitem in data.strip('\0').split(' '):
+        for dataitem in data.split(' '):
             dataparts = dataitem.split('=')
             if dataparts[0] == 'T':
                 res[MI_TEMPERATURE] = float(dataparts[1])

--- a/test/unit_tests/test_parse.py
+++ b/test/unit_tests/test_parse.py
@@ -52,3 +52,13 @@ class KNXConversionTest(unittest.TestCase):
         poller._last_read = datetime.now()
         self.assertEqual(poller._parse_data()[MI_TEMPERATURE], -11.3)
         self.assertEqual(poller._parse_data()[MI_HUMIDITY], 37.6)
+
+    def test_parsing5(self):
+        """Does the Mi TEMP BT data parser works correctly with spurious binary data? Value: T=-11.3 H=53.0\x02"""
+        poller = MiTempBtPoller(None, MockBackend)
+        data = bytearray([0x54, 0x3d, 0x2d, 0x31, 0x31, 0x2e, 0x33, 0x20,
+                          0x48, 0x3d, 0x35, 0x33, 0x2e, 0x30, 0x02]).decode("utf-8").strip(' \n\t')
+        poller._cache = data
+        poller._last_read = datetime.now()
+        self.assertEqual(poller._parse_data()[MI_TEMPERATURE], -11.3)
+        self.assertEqual(poller._parse_data()[MI_HUMIDITY], 53.0)


### PR DESCRIPTION
Sometimes data has spurious binary data non properly decoded from utf-8
Example:
ValueError: could not convert string to float: '53.0\x02'

This fix #15 by removing not printable characters to reduce the chances of exceptions.