### PR TITLE
update setup.py to not install the 'test' packages at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5'
     ],
-    packages=find_packages(),
+    packages=find_packages('test','test.*'),
     install_requires=['btlewrap==0.0.8'],
     keywords='temperature and humidity sensor bluetooth low-energy ble',
     zip_safe=False,


### PR DESCRIPTION
```
>>> Emerging (1 of 1) dev-python/mitemp-bt-0.0.3::HomeAssistantRepository
>>> Failed to emerge dev-python/mitemp-bt-0.0.3, Log file:
>>>  '/var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.20, 0.16, 0.11
 * Package:    dev-python/mitemp-bt-0.0.3
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   developer@ratcash.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking mitemp-bt-0.0.3.tar.gz to /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work
>>> Source unpacked in /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work
>>> Preparing source in /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3 ...
locale: Cannot set LC_ALL to default locale: No such file or directory
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test
copying test/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test
copying test/helper.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test
copying test/conftest.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/mitemp_bt
copying mitemp_bt/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/mitemp_bt
copying mitemp_bt/mitemp_bt_poller.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/mitemp_bt
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests
copying test/unit_tests/test_parse.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests
copying test/unit_tests/test_mitemp_bt_poller.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests
copying test/unit_tests/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests
copying test/unit_tests/test_versioncheck.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
copying test/integration_tests/test_gatttool_backend.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
copying test/integration_tests/test_demo.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
copying test/integration_tests/test_everything.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
copying test/integration_tests/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
copying test/integration_tests/test_bluepy_backend.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/mitemp-bt-0.0.3

>>> Install dev-python/mitemp-bt-0.0.3 into /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9
running install
running install_lib
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests/test_parse.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests/test_mitemp_bt_poller.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/unit_tests/test_versioncheck.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/helper.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests/test_gatttool_backend.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests/test_demo.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests/test_everything.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/integration_tests/test_bluepy_backend.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/test/conftest.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test
creating /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/mitemp_bt/__init__.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt
copying /var/tmp/portage/dev-python/mitemp-bt-0.0.3/work/mitemp_bt-0.0.3-python3_9/lib/mitemp_bt/mitemp_bt_poller.py -> /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_parse.py to test_parse.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_mitemp_bt_poller.py to test_mitemp_bt_poller.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_versioncheck.py to test_versioncheck.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/helper.py to helper.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_gatttool_backend.py to test_gatttool_backend.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_demo.py to test_demo.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_everything.py to test_everything.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_bluepy_backend.py to test_bluepy_backend.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/test/conftest.py to conftest.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt/mitemp_bt_poller.py to mitemp_bt_poller.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpfct9jphp.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpfct9jphp.py
removing /var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpfct9jphp.py
writing byte-compilation script '/var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpve1hbr_2.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpve1hbr_2.py
removing /var/tmp/portage/dev-python/mitemp-bt-0.0.3/temp/tmpve1hbr_2.py
running install_egg_info
running egg_info
writing mitemp_bt.egg-info/PKG-INFO
writing dependency_links to mitemp_bt.egg-info/dependency_links.txt
writing requirements to mitemp_bt.egg-info/requires.txt
writing top-level names to mitemp_bt.egg-info/top_level.txt
reading manifest file 'mitemp_bt.egg-info/SOURCES.txt'
writing manifest file 'mitemp_bt.egg-info/SOURCES.txt'
Copying mitemp_bt.egg-info to /var/tmp/portage/dev-python/mitemp-bt-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/mitemp_bt-0.0.3-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/mitemp-bt-0.0.3::HomeAssistantRepository failed (install phase):
 *   Package installs 'test' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2845:  Called distutils-r1_src_install
 *   environment, line 1182:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  453:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2520:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2051:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2049:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  767:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1150:  Called distutils-r1_python_install
 *   environment, line 1053:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
```